### PR TITLE
Allow pre-release (EKS) kubernetes versions

### DIFF
--- a/charts/gcp-workload-identity-federation-webhook/Chart.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: gcp-workload-identity-federation-webhook
 description: A Helm chart for gcp-workload-identity-federation-webhook
-kubeVersion: "^1.21.0"
+kubeVersion: "^1.21.0-0"
 home: https://github.com/pfnet-research/gcp-workload-identity-federation-webhook/
 # A chart can be either an 'application' or a 'library' chart.
 #


### PR DESCRIPTION
As described in https://github.com/helm/helm/issues/9371, adding `-0` to the SemVer string allows pre-release versions to be included in the permitted versions. This is necessary for installing the chart on EKS.